### PR TITLE
Added support for custom ips for containers

### DIFF
--- a/blockade/config.py
+++ b/blockade/config.py
@@ -60,7 +60,9 @@ class BlockadeContainerConfig(object):
                 neutral=values.get('neutral', False),
                 holy=values.get('holy', False),
                 container_name=with_index(values.get('container_name'), idx),
-                cap_add=values.get('cap_add'))
+                cap_add=values.get('cap_add'),
+                ipv4_address=values.get('ipv4_address'),
+                docker_network=values.get('docker_network'))
 
         if count == 1:
             yield get_instance(name)
@@ -72,7 +74,7 @@ class BlockadeContainerConfig(object):
     def __init__(self, name, image, command=None, links=None, volumes=None,
                  publish_ports=None, expose_ports=None, environment=None,
                  hostname=None, dns=None, start_delay=0, neutral=False,
-                 holy=False, container_name=None, cap_add=None):
+                 holy=False, container_name=None, cap_add=None, ipv4_address=None, docker_network=None):
         self.name = name
         self.hostname = hostname
         self.dns = dns
@@ -85,6 +87,8 @@ class BlockadeContainerConfig(object):
         self.holy = holy
         self.container_name = container_name
         self.cap_add = cap_add
+        self.ipv4_address = ipv4_address
+        self.docker_network = docker_network
 
         if neutral and holy:
             raise BlockadeConfigError("container must not be 'neutral' and 'holy' at the same time")
@@ -124,6 +128,7 @@ class BlockadeConfig(object):
         Instantiate a BlockadeConfig instance based on
         a given dictionary of configuration values
         '''
+
         try:
             containers = values['containers']
             parsed_containers = {}

--- a/blockade/core.py
+++ b/blockade/core.py
@@ -158,6 +158,15 @@ class Blockade(object):
 
         def create_container():
             # try to create container
+            if container.docker_network and container.ipv4_address:
+                container.networking_config = self.docker_client.create_networking_config({
+                    container.docker_network: self.docker_client.create_endpoint_config(
+                        ipv4_address=container.ipv4_address
+                    )
+                })
+            else:
+                container.networking_config = None
+
             response = self.docker_client.create_container(
                 container.image,
                 command=container.command,
@@ -167,7 +176,8 @@ class Blockade(object):
                 hostname=container.hostname,
                 environment=container.environment,
                 host_config=host_config,
-                labels={"blockade.id": self.state.blockade_id})
+                labels={"blockade.id": self.state.blockade_id},
+                networking_config=container.networking_config)
             return response['Id']
 
         try:


### PR DESCRIPTION
Support custom networks and ips for the containers, leveraging the --net and --ip flags from docker, instead of juggling with env variables like $C1_PORT_10000_TCP_ADDR that cannot solve cyclic dependencies anyway