### PR TITLE
Update requirements to allow more recent versions of packages

### DIFF
--- a/blockade/api/rest.py
+++ b/blockade/api/rest.py
@@ -18,7 +18,7 @@ import sys
 import traceback
 
 from flask import Flask, abort, jsonify, request, Response
-from gevent.wsgi import WSGIServer
+from gevent.pywsgi import WSGIServer
 
 from blockade import chaos
 from blockade import errors

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-PyYAML==3.11
-clint==0.4.1
-docker==2.1.0
-six==1.9.0
-flask==0.10.1
-gevent==1.1.1
+PyYAML>=3.11,<6.0
+clint>=0.4.1,<0.6
+docker>=2.1.0,<3.8
+six>=1.9.0,<1.12.0
+flask>=0.10.1,<1.0
+gevent>=1.1.1,<1.5

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
 coverage
 nose
 mock
-Flask-Testing==0.5.0
+Flask-Testing>=0.5.0,<0.6.0


### PR DESCRIPTION
I loosened the version requirements a little bit to allow more recent versions of stuff that didn't break things. Getting the latest flask to work would be a little more effort.